### PR TITLE
Fix case when there are more than 9 delays

### DIFF
--- a/check_lsyncd
+++ b/check_lsyncd
@@ -64,7 +64,7 @@ if [ ! -f "$statusfile" ]; then
 fi
 
 # Get number of delays from statusfile
-delays=$(awk '/^There are [0-9] delays/ { count += $3; } END { print count; }' "$statusfile")
+delays=$(awk '/^There are [0-9]+ delays/ { count += $3; } END { print count; }' "$statusfile")
 if [ "$delays" -ge $crit_delays ]; then
 	echo "lsyncd CRITICAL: there are $delays delays | delay=$delays"
 	exit 2


### PR DESCRIPTION
This PR fixes case when there are more than 9 delays. This is the observed behaviour:

```
# ./check_lsyncd
./check_lsyncd: line 68: [: : integer expression expected
./check_lsyncd: line 71: [: : integer expression expected
lsyncd OK:  delays | delay=
```

After the fix is implemented we are able to properly see all the delays, even if the number is greater than 9:

```
# ./check_lsyncd
lsyncd OK: 7 delays | delay=7
# ./check_lsyncd
lsyncd OK: 0 delays | delay=0
# ./check_lsyncd
lsyncd OK: 0 delays | delay=0
# ./check_lsyncd
lsyncd WARNING: there are 22 delays | delay=22
```